### PR TITLE
Make username & password case-sensitive

### DIFF
--- a/MomentuumApi/Controllers/AuthenticationController.cs
+++ b/MomentuumApi/Controllers/AuthenticationController.cs
@@ -34,19 +34,15 @@ namespace MomentuumApi.Controllers
         public IActionResult Login([FromBody]LoginModel login)
         {
             IActionResult response = Unauthorized();
-
             TblEmployees employee = _context.TblEmployees.FirstOrDefault(emp => emp.EmployeeLogin.Equals(login.Username));
 
-            if (employee != null && employee.UsrPassword.Equals(login.Password)) 
-            {
-                string loginId = employee.EmployeeLogin;
-                string password = employee.UsrPassword;
+            string loginId = employee?.EmployeeLogin;
+            string password = employee?.UsrPassword;
 
-                if (loginId.Equals(login.Username) && password.Equals(login.Password))
-                {
-                    var tokenString = BuildToken(login);
-                    response = Ok(new { token = tokenString });
-                }
+            if (loginId.Equals(login.Username) && password.Equals(login.Password))
+            {
+                var tokenString = BuildToken(login);
+                response = Ok(new { token = tokenString });
             }
 
             return response;


### PR DESCRIPTION
The reason why it was case sensitive is, because MS SQL Server is itself case insensitive
 by default and entity framework treats it that way.
We can solve this issue by doing the comparison from a simple object instead of doing it through Entity Framework.

Fixes #11 